### PR TITLE
Replace np.float and np.object across 2 files (removed in NumPy 1.24)

### DIFF
--- a/simulation/leaderboard/team_code/coop_agent.py
+++ b/simulation/leaderboard/team_code/coop_agent.py
@@ -476,9 +476,9 @@ class ImageAgent(AutonomousAgent):
         control = carla.VehicleControl()
         pid_control = self._agent._local_planner.run_step(goal = 'Forward')
         if pred_throttle is not None:
-            control.throttle = np.float(pred_throttle)*1.5
-            control.brake = np.float(pred_brake)
-            control.steer = np.float(pred_steer)
+            control.throttle = float(pred_throttle)*1.5
+            control.brake = float(pred_brake)
+            control.steer = float(pred_steer)
             print("Model's Output:\t[{:.2f},\t{:.2f},\t{:.2f}]".format(control.throttle, control.brake, control.steer))
             if control.brake >= control.throttle or control.brake>0.7:
                 control.throttle = 0.0

--- a/simulation/leaderboard/team_code/transfuser_agent.py
+++ b/simulation/leaderboard/team_code/transfuser_agent.py
@@ -483,7 +483,7 @@ class HybridAgent(autonomous_agent.AutonomousAgent):
 
     def non_maximum_suppression(self, bounding_boxes, iou_treshhold):
         filtered_boxes = []
-        bounding_boxes = np.array(list(itertools.chain.from_iterable(bounding_boxes)), dtype=np.object)
+        bounding_boxes = np.array(list(itertools.chain.from_iterable(bounding_boxes)), dtype=object)
 
         if(bounding_boxes.size == 0): #If no bounding boxes are detected can't do NMS
             return filtered_boxes


### PR DESCRIPTION
Thanks for putting this code out — I've been reading through it.

On a current environment (Python 3.12, NumPy 2.x) it uses a few names that NumPy and the stdlib have since removed. These raise rather than warn, so execution stops at the first one reached.

### What breaks

| Location | Symbol | Removed in |
|---|---|---|
| `simulation/leaderboard/team_code/transfuser_agent.py:486` | `np.object` | NumPy 1.24 |
| `simulation/leaderboard/team_code/coop_agent.py:479` | `np.float` | NumPy 1.24 |
| `simulation/leaderboard/team_code/coop_agent.py:480` | `np.float` | NumPy 1.24 |
| `simulation/leaderboard/team_code/coop_agent.py:481` | `np.float` | NumPy 1.24 |

### How I checked

I couldn't stand up the full stack locally (it needs `carla`, which I don't have set up here), so rather than guess I executed each of these expressions directly against NumPy 2.x to confirm it genuinely raises, and confirmed the replacement returns the same value. The change is limited strictly to those substitutions.

Every file this touches still compiles (`py_compile`).

### What this PR changes

| Old | New | Why it's equivalent |
|---|---|---|
| `np.float` | `float` | `np.float` *was* the builtin `float` |
| `np.object` | `object` | alias for the builtin `object` |

These are exact substitutions — no behavioural or numerical change. Only the lines listed above are touched.

Happy to rework this if you'd rather pin NumPy below 2, or if you'd prefer it split differently.